### PR TITLE
Docker updates

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+README.md
+LICENSE
+.gitignore
+.github

--- a/variants/README.md
+++ b/variants/README.md
@@ -1,0 +1,18 @@
+# Variants
+Unix ports of CircuitPython (and MicroPython) use variants instead of board definitions. These variants are used to build versions of CircuitPython intended mostly for testing purposes.
+
+The `coverage` variant is compiled with most libraries, but also contains debug and profiling extras that may not be desired. The `standard`, `minimal`, and `nanbox` variants exist, do not contain any of the built-in CircuitPython libraries. The `minimal` and `nanbox` variants have even less features enabled.
+
+In order to build a version of CircuitPython with the libraries and without the debug hooks, a new variant must be defined. This is the `container` variant.
+
+For more details on the types of available variant definitions, see the CircuitPython repository: https://github.com/adafruit/circuitpython/tree/main/ports/unix/variants
+
+## Building
+
+Contents of this directory is copied to `/circuitpython/ports/unix/variants/` before being compiled.
+
+By default, the `container` variant is used, however custom variants can be built by setting the `VARIANT` build arg to the name of the custom variant's directory. For example a variant titled `mycustomvariant` would be built with the following command.
+
+```text
+docker build -t circuitpython --build-arg="VARIANT=mycustomvariant" .
+```

--- a/variants/container/manifest.py
+++ b/variants/container/manifest.py
@@ -1,0 +1,1 @@
+include("$(PORT_DIR)/variants/manifest.py")

--- a/variants/container/mpconfigvariant.h
+++ b/variants/container/mpconfigvariant.h
@@ -1,0 +1,36 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+// Set base feature level.
+#define MICROPY_CONFIG_ROM_LEVEL (MICROPY_CONFIG_ROM_LEVEL_FULL_FEATURES)
+
+// Enable extra Unix features.
+#include "../mpconfigvariant_common.h"
+
+// CIRCUITPY-CHANGE: Disable things never used in circuitpython
+#define MICROPY_PY_CRYPTOLIB            (0)
+#define MICROPY_PY_CRYPTOLIB_CTR        (0)
+#define MICROPY_PY_STRUCT               (0) // uses shared-bindings struct

--- a/variants/container/mpconfigvariant.mk
+++ b/variants/container/mpconfigvariant.mk
@@ -1,0 +1,48 @@
+# This is the default variant when you `make` the Unix port.
+FROZEN_MANIFEST ?= $(VARIANT_DIR)/manifest.py
+
+SRC_BITMAP := \
+	shared/runtime/context_manager_helpers.c \
+	displayio_min.c \
+	shared-bindings/__future__/__init__.c \
+	shared-bindings/aesio/aes.c \
+	shared-bindings/aesio/__init__.c \
+	shared-bindings/bitmapfilter/__init__.c \
+	shared-bindings/bitmaptools/__init__.c \
+	shared-bindings/codeop/__init__.c \
+	shared-bindings/displayio/Bitmap.c \
+	shared-bindings/displayio/ColorConverter.c \
+	shared-bindings/displayio/Palette.c \
+	shared-bindings/getpass/__init__.c \
+	shared-bindings/locale/__init__.c \
+	shared-bindings/traceback/__init__.c \
+	shared-bindings/util.c \
+	shared-bindings/zlib/__init__.c \
+	shared-module/aesio/aes.c \
+	shared-module/aesio/__init__.c \
+	shared-module/bitmapfilter/__init__.c \
+	shared-module/bitmaptools/__init__.c \
+	shared-module/displayio/area.c \
+	shared-module/displayio/Bitmap.c \
+	shared-module/displayio/ColorConverter.c \
+	shared-module/displayio/Palette.c \
+	shared-module/getpass/__init__.c \
+	shared-module/os/getenv.c \
+	shared-module/struct/__init__.c \
+	shared-module/traceback/__init__.c \
+	shared-module/zlib/__init__.c \
+
+SRC_C += $(SRC_BITMAP)
+
+CFLAGS += \
+	-DCIRCUITPY_AESIO=1 \
+	-DCIRCUITPY_BITMAPTOOLS=1 \
+	-DCIRCUITPY_CODEOP=1 \
+	-DCIRCUITPY_DISPLAYIO_UNIX=1 \
+	-DCIRCUITPY_FUTURE=1 \
+	-DCIRCUITPY_GETPASS=1 \
+	-DCIRCUITPY_LOCALE=1 \
+	-DCIRCUITPY_OS_GETENV=1 \
+	-DCIRCUITPY_STRUCT=1 \
+	-DCIRCUITPY_TRACEBACK=1 \
+	-DCIRCUITPY_ZLIB=1


### PR DESCRIPTION
- Set `$MICROPYPATH` to the `lib/` directory.
- Customize CircuitPython at build time. (closes #2)